### PR TITLE
chore: ajout du fichier CODEOWNERS (CP-5118)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @croesusfin/croesus-plateforme


### PR DESCRIPTION
Cette PR ajoute un fichier CODEOWNERS avec @croesusfin/croesus-plateforme comme propriétaire par défaut.

https://croesus-support.atlassian.net/browse/CP-5118
